### PR TITLE
Show parameters that cause test failures

### DIFF
--- a/factcheck.py
+++ b/factcheck.py
@@ -7,6 +7,7 @@ import sys
 import random
 from itertools import product, cycle, repeat, islice, chain
 import inspect
+from pprint import pformat
 
 
 if sys.version_info[0] > 2:
@@ -166,7 +167,11 @@ def forall(_test_fn=None, samples=1000, where=_always, **parameter_generators):
                 param_bindings = dict(zip(param_names, param_values))
                 
                 if where(**where_bindings(param_bindings)):
-                    test_fn(*args, **param_bindings)
+                    try:
+                        test_fn(*args, **param_bindings)
+                    except AssertionError as e:
+                        e.args = ("%s\nFailing parameters:\n%s" % (e.args[0], pformat(param_bindings)),)
+                        raise
         
         return bound_test_fn
     


### PR DESCRIPTION
Hi Nat,

In this morning's session, we discussed how it was difficult to tell what parameter values caused an assertion to fail.  I've just modified factcheck to add them to the assertion message.

This doesn't do anything for other exceptions, since I didn't want to overwrite other exception arguments (for an AssertionError, all of the message is in args[0]).

I've found this useful, so feel free to pull it if you want, or drop it if you're not happy with it.

Matt
